### PR TITLE
replace cors proxy with api.allorigins.win

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,7 +210,7 @@ var a = new Vue({
         spaceModeOn();
       } else {
         spaceModeOff();
-        var url = "https://s1-fmt2.liveatc.net/" + code;
+        var url = "https://api.allorigins.win/raw?url=https://s1-fmt2.liveatc.net/" + code;
         $("#stream").attr("src", url);
       }
 


### PR DESCRIPTION
GitHub Pages does not support backend proxying, so direct LiveATC audio requests fail under the server's strict cross-origin/referrer policy. This change routes stream requests through `api.allorigins.win/raw` to restore audio playback without requiring a server-side host.

The previous CORS fix in `index.html` (removing `crossOrigin="anonymous"`) did not address the real issue, because the block happens at the LiveATC server before the browser can complete the request.